### PR TITLE
fix(js): call parent initObservable method to fix undefined this.elems

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/buybox_payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/buybox_payment.js
@@ -26,7 +26,7 @@ define(
                 template: 'BuyBox_Payment/payment/form'
             },
             initObservable: function () {
-                return this;
+                return this._super();
             },
 
             getCode: function () {


### PR DESCRIPTION
In the checkout when BuyBox is enabled, we get this JS error : 
 
```
VM8976:10 Uncaught TypeError: this.elems is not a function
    at UiClass._updateCollection (eval at require.load (static.min.js:11:216), <anonymous>:10:459)
    at UiClass._insert (eval at require.load (static.min.js:11:216), <anonymous>:10:6)
    at Registry._resolveRequest (eval at require.load (static.min.js:11:216), <anonymous>:18:439)
    at Array.forEach (<anonymous>)
    at Registry._updateRequests (eval at require.load (static.min.js:11:216), <anonymous>:18:235)
    at later (eval at require.load (static.min.js:11:216), <anonymous>:43:255)
```

That may affect the smooth operation of other payment methods.
To prevent this error, we need to call the parent function which initialize this.elems. The parent function look like that : 

```
        initObservable: function () {
            this._super()
                .observe({
                    elems: []
                });

            return this;
        },
```