### PR TITLE
feat: new revision compatible php8.3 for magento 2.4.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,9 @@
   "name": "buybox/giftcard-payment-magento2",
   "description": "BuyBox GiftCard Payment integration with Magento 2",
   "type": "magento2-module",
-  "version": "2.4.6.1",
+  "version": "2.4.6.2",
   "require": {
-    "php": "~7.4.0||~8.1.0||~8.2.0",
+    "php": "~7.4.0||~8.1.0||~8.2.0||~8.3.0",
     "magento/framework": ">=103.0.0",
     "magento/module-sales": ">=103.0.0",
     "magento/module-checkout": ">=100.4.0",


### PR DESCRIPTION
Hello,

Here is a PR tu add compatibility for PHP8.3 in composer.json, as Magento >= 2.4.7 is now compatible with it.
I have done some tests and I can still use extension without any issue.


Regards.